### PR TITLE
Automatic prod deployments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,8 @@ jobs:
       - name: Deploy PR to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
-          project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
+          service-key: ${{ secrets.PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.PREVIEW_GOOGLE_PROJECT_ID }}
           bucket-name: preview.threshold.network
           bucket-path: ${{ github.head_ref }}
           build-folder: build
@@ -84,8 +84,8 @@ jobs:
       - name: Deploy build to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          service-key: ${{ secrets.MAINNET_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
-          project: ${{ secrets.MAINNET_GOOGLE_PROJECT_ID }}
+          service-key: ${{ secrets.PROD_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.PROD_GOOGLE_PROJECT_ID }}
           bucket-name: threshold.network
           build-folder: build
           set-website: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: yarn build
         env:
-          PUBLIC_URL: /${{ github.ref_name }}
+          PUBLIC_URL: /${{ github.head_ref }}
 
       - name: Build
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,8 @@ jobs:
       - name: Deploy PR to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0
         with:
-          service-key: ${{ secrets.PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
-          project: ${{ secrets.PREVIEW_GOOGLE_PROJECT_ID }}
+          service-key: ${{ secrets.PROD_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.PROD_PREVIEW_GOOGLE_PROJECT_ID }}
           bucket-name: preview.threshold.network
           bucket-path: ${{ github.head_ref }}
           build-folder: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,92 @@
+name: Thrershold Website CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build preview
+        if: github.event_name == 'pull_request'
+        run: yarn build
+        env:
+          PUBLIC_URL: /${{ github.ref_name }}
+
+      - name: Build
+        if: github.event_name == 'push'
+        run: yarn build
+        env:
+          PUBLIC_URL: /
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build
+
+  deploy-preview:
+    name: Deploy preview
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+
+      - name: Deploy PR to GCP
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        with:
+          service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
+          bucket-name: preview.threshold.network
+          bucket-path: ${{ github.ref_name }}
+          build-folder: build
+
+      - name: Post preview URL to PR
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Preview uploaded to https://preview.threshold.network/${{ github.head_ref }}/index.html.'
+            })
+
+  deploy:
+    name: Deploy
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+
+      - name: Deploy build to GCP
+        uses: thesis/gcp-storage-bucket-action@v3.1.0
+        with:
+          service-key: ${{ secrets.MAINNET_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
+          project: ${{ secrets.MAINNET_GOOGLE_PROJECT_ID }}
+          bucket-name: threshold.network
+          build-folder: build
+          set-website: true
+          home-page-path: index.html
+          error-page-path: index.html

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           service-key: ${{ secrets.MAINNET_PREVIEW_UPLOADER_SERVICE_KEY_JSON_BASE64 }}
           project: ${{ secrets.MAINNET_PREVIEW_GOOGLE_PROJECT_ID }}
           bucket-name: preview.threshold.network
-          bucket-path: ${{ github.ref_name }}
+          bucket-path: ${{ github.head_ref }}
           build-folder: build
 
       - name: Post preview URL to PR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,9 @@ jobs:
     name: Deploy
     needs: build
     if: github.event_name == 'push'
+    # production environment is protected, it requires an approval before execution.
+    environment:
+      name: prod
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/ci.yaml @pdyraga @nkuba @lukasz-zimnoch


### PR DESCRIPTION
Closes: #7 

This PR adds a GH workflow that deploys the preview to `preview.threshold.network` on every pull request that targets to `main` branch and deploys website to `threshold.network` on push to `main` branch.