### PR TITLE
Gatsby improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gatsby-source-filesystem": "^4.9.1",
     "gatsby-transformer-remark": "^5.9.1",
     "gatsby-transformer-sharp": "^4.9.0",
+    "markdown-it": "^12.3.2",
     "netlify-cms-app": "^2.15.68",
     "netlify-cms-widget-colorpicker": "^1.0.3",
     "path-that-svg": "^1.2.4",
@@ -67,6 +68,7 @@
   },
   "devDependencies": {
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep#d6ec02e",
+    "@types/markdown-it": "^12.2.3",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "eslint": "^7.32.0",

--- a/src/templates/home-page/HarnessThePower/ImageStack.tsx
+++ b/src/templates/home-page/HarnessThePower/ImageStack.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react"
-import { HStack, Stack, Square, Box } from "@chakra-ui/react"
-import { LabelMd } from "../../../components/Typography"
+import { HStack, Stack, Square } from "@chakra-ui/react"
+import { BodyMd, LabelMd } from "../../../components/Typography"
 import { Image, ImageProps } from "../../../components"
 
 const ImageStack: FC<{
@@ -24,9 +24,9 @@ const ImageStack: FC<{
           <Square bg="brand.500" w="20px" h="20px" />
           <LabelMd>{title}</LabelMd>
         </HStack>
-        <Box
+        <BodyMd
           mt="1rem"
-          layerStyle="bodyMd"
+          as="div"
           dangerouslySetInnerHTML={{ __html: description }}
         />
       </Stack>

--- a/src/templates/home-page/HarnessThePower/ImageStack.tsx
+++ b/src/templates/home-page/HarnessThePower/ImageStack.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from "react"
-import { HStack, Stack, Square } from "@chakra-ui/react"
-import { BodyMd, LabelMd } from "../../../components/Typography"
+import { FC } from "react"
+import { HStack, Stack, Square, Box } from "@chakra-ui/react"
+import { LabelMd } from "../../../components/Typography"
 import { Image, ImageProps } from "../../../components"
 
 const ImageStack: FC<{
@@ -24,7 +24,11 @@ const ImageStack: FC<{
           <Square bg="brand.500" w="20px" h="20px" />
           <LabelMd>{title}</LabelMd>
         </HStack>
-        <BodyMd mt="1rem !important">{description}</BodyMd>
+        <Box
+          mt="1rem"
+          layerStyle="bodyMd"
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
       </Stack>
     </Stack>
   )

--- a/src/templates/home-page/index.tsx
+++ b/src/templates/home-page/index.tsx
@@ -20,7 +20,6 @@ const SplashPageTemplate: FC<any> = ({ data }) => {
     activeCommunity,
     joinTheCommunity,
   } = data.markdownRemark.frontmatter
-
   return (
     <>
       <Hero {...hero} />
@@ -162,7 +161,7 @@ export const query = graphql`
         harnessThePower {
           title
           subitems {
-            description
+            description(from: "description")
             title
             image {
               id

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -36,13 +36,6 @@ const colors = {
   },
 }
 
-const layerStyles = {
-  bodyMd: {
-    fontSize: "16px",
-    lineHeight: "24px",
-  },
-}
-
 const index = extendTheme({
   config,
   breakpoints,
@@ -51,7 +44,6 @@ const index = extendTheme({
     Button,
     Card,
   },
-  layerStyles,
   styles: {
     global: {
       a: {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -36,6 +36,13 @@ const colors = {
   },
 }
 
+const layerStyles = {
+  bodyMd: {
+    fontSize: "16px",
+    lineHeight: "24px",
+  },
+}
+
 const index = extendTheme({
   config,
   breakpoints,
@@ -44,6 +51,7 @@ const index = extendTheme({
     Button,
     Card,
   },
+  layerStyles,
 })
 
 export default index

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -52,6 +52,22 @@ const index = extendTheme({
     Card,
   },
   layerStyles,
+  styles: {
+    global: {
+      a: {
+        // To style the `a` tag from cms we assume that these tags don't include
+        // `class` attribute.
+        ":not([class])": {
+          textDecoration: "underline !important",
+          // Add an arrow if it is an external link.
+          '&[href^="http"]::after': {
+            content: '" ↗"',
+            whiteSpace: "pre",
+          },
+        },
+      },
+    },
+  },
 })
 
 export default index

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,6 +4768,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/linkify-it@*":
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
+  integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
+
 "@types/lodash.mergewith@4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
@@ -4785,12 +4790,25 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
   integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
 
+"@types/markdown-it@^12.2.3":
+  version "12.2.3"
+  resolved "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
+  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+  dependencies:
+    "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.10"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
   integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
   dependencies:
     "@types/unist" "*"
+
+"@types/mdurl@*":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/minimatch@*":
   version "3.0.5"
@@ -5815,6 +5833,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-hidden@^1.1.1:
   version "1.1.3"
@@ -8911,6 +8934,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 envinfo@^7.8.1:
   version "7.8.1"
@@ -13418,6 +13446,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@>=10:
   version "11.2.6"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.6.tgz#f477b1af0294db054e5937f171679df63baa4c43"
@@ -13816,6 +13851,17 @@ markdown-escapes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 markdown-table@^1.1.0:
   version "1.1.3"
@@ -20507,6 +20553,11 @@ typescript@^4.4.3:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Main changes:
* Create a `md` field extension that renders the markdown field from
`frontmatter` scope(in `md` file) into a html. To use this field
extension we must define types for GrapQL which field should use this
extension. For reference check `createSchemaCustomization` function in
the `gatsby-node.ts` file. Implemented based on the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#creating-custom-extensions).
* Style the a tag from cms- To style the `a` tag from cms we **assume** that these tags don't include
the `class` attribute. Add an arrow if it is an external link.