### PR TITLE
DAO Treasury Holdings

### DIFF
--- a/src/config/ethereum.ts
+++ b/src/config/ethereum.ts
@@ -1,0 +1,7 @@
+import { providers } from "ethers"
+
+// TODO: Set correct Infura url.
+const INFURA_URL =
+  "https://mainnet.infura.io/v3/c80e8ccdcc4c4a809bce4fc165310617"
+
+export const defaultWeb3Provider = new providers.JsonRpcProvider(INFURA_URL)

--- a/src/content/components/dao-treasury-tokens.md
+++ b/src/content/components/dao-treasury-tokens.md
@@ -1,0 +1,10 @@
+---
+template: dao-treasury-tokens
+tokens:
+  - address: "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+    coingeckoId: keep-network
+  - address: "0x62B9c7356A2Dc64a1969e19C23e4f579F9810Aa7"
+    coingeckoId: convex-crv
+  - address: "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5"
+    coingeckoId: threshold-network-token
+---

--- a/src/hooks/useBalanceOfDAOTreasury.ts
+++ b/src/hooks/useBalanceOfDAOTreasury.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react"
+import { graphql, useStaticQuery } from "gatsby"
+import { FixedNumber } from "ethers"
+import { CoingeckoID, exchangeAPI, formatUnits } from "../utils"
+import { useERC20TokensBalanceCall } from "./useERC20TokensBalanceCall"
+
+// https://etherscan.io/address/0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f
+const DAO_TREASURY_ADDRESS = "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f"
+
+const query = graphql`
+  query {
+    markdownRemark(frontmatter: { template: { eq: "dao-treasury-tokens" } }) {
+      id
+      frontmatter {
+        tokens {
+          address
+          coingeckoId
+        }
+      }
+    }
+  }
+`
+export const useBalanceOfDAOTreasury = () => {
+  const [totalTreasuryInUSD, setTotalTreasuryInUSD] = useState("0")
+
+  const data = useStaticQuery(query)
+  const { tokens }: { tokens: { address: string; coingeckoId: string }[] } =
+    data.markdownRemark.frontmatter
+  const getTokenBalances = useERC20TokensBalanceCall(
+    tokens.map(({ address }) => address),
+    DAO_TREASURY_ADDRESS
+  )
+
+  useEffect(() => {
+    const fetchTokenBalances = async () => {
+      const tokenBalances = await getTokenBalances()
+      const tokenPrices = await Promise.all(
+        tokens.map(({ coingeckoId }) =>
+          exchangeAPI.fetchCryptoCurrencyPriceUSD(coingeckoId as CoingeckoID)
+        )
+      )
+      const _totalTreasuryInUSD = tokenBalances.reduce(
+        (reducer: FixedNumber, tokenBalance: string[], index: number) => {
+          const tokenValue = exchangeAPI.toUsdBalance(
+            formatUnits(tokenBalance.toString()),
+            tokenPrices[index]
+          )
+          return reducer.addUnsafe(tokenValue)
+        },
+        FixedNumber.fromString("0")
+      )
+      setTotalTreasuryInUSD(_totalTreasuryInUSD)
+    }
+    fetchTokenBalances()
+  }, [getTokenBalances])
+
+  return totalTreasuryInUSD
+}

--- a/src/hooks/useERC20TokensBalanceCall.ts
+++ b/src/hooks/useERC20TokensBalanceCall.ts
@@ -1,0 +1,17 @@
+import { Contract } from "ethers"
+import { useMulticall } from "./useMulticall"
+
+const ERC20_ABI = ["function balanceOf(address owner) view returns (uint256)"]
+
+export const useERC20TokensBalanceCall = (
+  tokenAddresses: string[],
+  address: string
+) => {
+  return useMulticall(
+    tokenAddresses.map((tokenAddress) => ({
+      contract: new Contract(tokenAddress, ERC20_ABI),
+      method: "balanceOf",
+      args: [address],
+    }))
+  )
+}

--- a/src/hooks/useMulticall.ts
+++ b/src/hooks/useMulticall.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react"
+import { Contract } from "ethers"
+import { defaultWeb3Provider } from "../config/ethereum"
+
+interface ContractCall {
+  contract: Contract
+  method: string
+  args?: any[]
+}
+
+const MULTICALL_ABI = [
+  "function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)",
+  "function getEthBalance(address addr) view returns (uint256 balance)",
+]
+
+// Address exported from:
+// https://github.com/makerdao/multicall#multicall-contract-addresses
+const MULTICALL_ADDRESS = "0xeefba1e63905ef1d7acba5a8513c70307c1ce441"
+
+const multicallContract = new Contract(
+  MULTICALL_ADDRESS,
+  MULTICALL_ABI,
+  defaultWeb3Provider
+)
+
+export const useMulticall = (calls: ContractCall[]) => {
+  const callRequests = calls.map((_) => [
+    _.contract?.address,
+    _.contract?.interface.encodeFunctionData(_.method, _.args),
+  ])
+
+  return useCallback(async () => {
+    if (!multicallContract || !callRequests || callRequests.length === 0) {
+      return []
+    }
+
+    const [, result] = await multicallContract.aggregate(callRequests)
+    return result.map((data: string, index: number) => {
+      const call = calls[index]
+      return call.contract.interface.decodeFunctionResult(call.method, data)
+    })
+  }, [JSON.stringify(callRequests), multicallContract])
+}

--- a/src/templates/governance-page/ThresholdDaoDataSection.tsx
+++ b/src/templates/governance-page/ThresholdDaoDataSection.tsx
@@ -10,10 +10,11 @@ import { ExternalLinkHref } from "../../components/Navbar/types"
 import { StatBoxGroup } from "../../components/StatBox"
 import { T_NETWORK_SUBGRAPH_URL } from "../../config/subgraph"
 import useQuery from "../../hooks/useQuery"
-import { formatTokenAmount } from "../../utils"
+import { formatFiatCurrencyAmount, formatTokenAmount } from "../../utils"
+import { useBalanceOfDAOTreasury } from "../../hooks/useBalanceOfDAOTreasury"
 
 const ThresholdDaoDataSection = () => {
-  const totalTreasuryHoldings = "$50,000,000"
+  const totalTreasuryHoldings = useBalanceOfDAOTreasury()
 
   const { data } = useQuery<{
     daometric: { liquidTotal: string; stakedTotal: string }
@@ -68,7 +69,7 @@ const ThresholdDaoDataSection = () => {
         <HStack justifyContent="space-between" mb={16}>
           <Stack spacing={6}>
             <LabelMd color="gray.500">Total Treasury Holdings</LabelMd>
-            <H2>{totalTreasuryHoldings}</H2>
+            <H2>{formatFiatCurrencyAmount(totalTreasuryHoldings)}</H2>
           </Stack>
           <ExternalButtonLink
             display={{ base: "none", md: "inherit" }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -2677,3 +2677,34 @@ collections:
                   },
                 ],
             }
+      - file: "src/content/components/dao-treasury-tokens.md"
+        label: "DAO Treasury Holding Tokens"
+        name: "daoTreasuryTokens"
+        fields:
+          - {
+              label: "Template Key",
+              name: "template",
+              widget: "hidden",
+              default: "dao-treasury-tokens",
+            }
+          - {
+              label: "Token Addresses",
+              name: "tokens",
+              widget: "list",
+              allow_add: true,
+              fields:
+                [
+                  {
+                    label: "Token Address",
+                    name: "address",
+                    widget: "string",
+                    required: true,
+                  },
+                  {
+                    label: CoinGecko ID",
+                    name: "coingeckoId",
+                    widget: "string",
+                    required: true,
+                  },
+                ],
+            }


### PR DESCRIPTION
Depends on: #44 

This PR adds support for fetching the balances of DAO Treasury's tokens. New tokens can be added via cms so there is no need to make any changes in the code to take into account the new token.