### PR TITLE
fix(href): :bug: Correct a broken link 

### DIFF
--- a/src/content/pages/earn/staker.md
+++ b/src/content/pages/earn/staker.md
@@ -106,7 +106,7 @@ gettingStarted:
         leftIcon: /images/document.svg
       - leftIcon: /images/hardware-chip-sharp.svg
         label: Staking Providers
-        url: https://docs.nucypher.com/en/latest/pre_application/node_providers.htmlF
+        url: https://docs.nucypher.com/en/latest/pre_application/node_providers.html
         rightIcon: /images/external-arrow.svg
       - leftIcon: /images/logo-discord.png
         label: Ask Questions in Discord


### PR DESCRIPTION
There is currently a broken link. The link resolves to a 404 because the ending URL is .htmlF instead of .html. This PR fixes the issue.

Breaking Changes: N/A