### PR TITLE
Posthog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         run: yarn build
         env:
           PUBLIC_URL: /
+          POSTHOG_SUPPORT: true
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
         env:
           PUBLIC_URL: /
           POSTHOG_SUPPORT: true
+          POSTHOG_API_KEY: ${{ secrets.MAINNET_POSTHOG_API_KEY }}
+          POSTHOG_HOSTNAME_HTTP: ${{ secrets.MAINNET_POSTHOG_HOSTNAME_HTTP }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,5 +1,88 @@
-import { GatsbyConfig } from "gatsby"
+import { GatsbyConfig, PluginRef } from "gatsby"
 import path from "path"
+
+const plugins: Array<PluginRef> = [
+  "gatsby-plugin-react-helmet",
+  {
+    resolve: "gatsby-plugin-manifest",
+    options: {
+      name: "Threshold Network",
+      short_name: "T Network",
+      description:
+        "Threshold powers user sovereignty on the public blockchain.",
+      start_url: "/",
+      background_color: "#1D2229", // grey 900
+      theme_color: "#7C47EE", // brand purple
+      display: "standalone",
+      icon: "src/static/images/favicon.png",
+    },
+  },
+  "gatsby-transformer-sharp",
+  "gatsby-plugin-sharp",
+  {
+    resolve: "gatsby-transformer-remark",
+    options: {
+      plugins: [
+        {
+          resolve: "gatsby-remark-relative-images",
+          options: {
+            name: "uploads",
+          },
+        },
+        {
+          resolve: "gatsby-remark-images",
+          options: {
+            // It's important to specify the maxWidth (in pixels) of
+            // the content container as this plugin uses this as the
+            // base for generating different widths of each image.
+            maxWidth: 2048,
+          },
+        },
+      ],
+    },
+  },
+  "@chakra-ui/gatsby-plugin",
+  {
+    resolve: "gatsby-source-filesystem",
+    options: {
+      path: path.resolve("static/images"),
+      name: "uploads",
+    },
+  },
+  {
+    resolve: "gatsby-source-filesystem",
+    options: {
+      path: path.resolve("src/content/components"),
+      name: "components",
+    },
+  },
+  {
+    resolve: "gatsby-source-filesystem",
+    options: {
+      path: path.resolve("src/content/pages"),
+      name: "pages",
+    },
+  },
+  {
+    resolve: "gatsby-plugin-netlify-cms",
+    options: {
+      modulePath: path.resolve("/src/cms/cms.ts"),
+    },
+  },
+]
+
+if (process.env["POSTHOG_SUPPORT"] === "true") {
+  plugins.push({
+    resolve: "gatsby-plugin-posthog",
+    options: {
+      apiKey: "phc_5XMnBAeMVxZQhmBm6G0Kee5ujBOiUhGYIakUKfDhgs5",
+      apiHost: "https://app.posthog.com",
+      initOptions: {
+        persistence: "memory",
+      },
+    },
+  })
+}
 
 const config: GatsbyConfig = {
   siteMetadata: {
@@ -10,75 +93,7 @@ const config: GatsbyConfig = {
     url: "https://threshold.network",
     twitterUsername: "@TheTNetwork",
   },
-  plugins: [
-    "gatsby-plugin-react-helmet",
-    {
-      resolve: "gatsby-plugin-manifest",
-      options: {
-        name: "Threshold Network",
-        short_name: "T Network",
-        description:
-          "Threshold powers user sovereignty on the public blockchain.",
-        start_url: "/",
-        background_color: "#1D2229", // grey 900
-        theme_color: "#7C47EE", // brand purple
-        display: "standalone",
-        icon: "src/static/images/favicon.png",
-      },
-    },
-    "gatsby-transformer-sharp",
-    "gatsby-plugin-sharp",
-    {
-      resolve: "gatsby-transformer-remark",
-      options: {
-        plugins: [
-          {
-            resolve: "gatsby-remark-relative-images",
-            options: {
-              name: "uploads",
-            },
-          },
-          {
-            resolve: "gatsby-remark-images",
-            options: {
-              // It's important to specify the maxWidth (in pixels) of
-              // the content container as this plugin uses this as the
-              // base for generating different widths of each image.
-              maxWidth: 2048,
-            },
-          },
-        ],
-      },
-    },
-    "@chakra-ui/gatsby-plugin",
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
-        path: path.resolve("static/images"),
-        name: "uploads",
-      },
-    },
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
-        path: path.resolve("src/content/components"),
-        name: "components",
-      },
-    },
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
-        path: path.resolve("src/content/pages"),
-        name: "pages",
-      },
-    },
-    {
-      resolve: "gatsby-plugin-netlify-cms",
-      options: {
-        modulePath: path.resolve("/src/cms/cms.ts"),
-      },
-    },
-  ],
+  plugins,
   pathPrefix: process.env["PUBLIC_URL"],
 }
 export default config

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -75,8 +75,8 @@ if (process.env["POSTHOG_SUPPORT"] === "true") {
   plugins.push({
     resolve: "gatsby-plugin-posthog",
     options: {
-      apiKey: "phc_5XMnBAeMVxZQhmBm6G0Kee5ujBOiUhGYIakUKfDhgs5",
-      apiHost: "https://app.posthog.com",
+      apiKey: process.env["POSTHOG_API_KEY"],
+      apiHost: process.env["POSTHOG_HOSTNAME_HTTP"],
       initOptions: {
         persistence: "memory",
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-plugin-image": "^2.9.1",
     "gatsby-plugin-manifest": "^4.11.1",
     "gatsby-plugin-netlify-cms": "^6.9.0",
+    "gatsby-plugin-posthog": "^1.0.1",
     "gatsby-plugin-react-helmet": "^5.11.0",
     "gatsby-plugin-sharp": "^4.9.1",
     "gatsby-remark-images": "^6.9.1",

--- a/src/content/components/role-quiz-modal.md
+++ b/src/content/components/role-quiz-modal.md
@@ -66,7 +66,7 @@ stages:
       title: Liquidity Provider
       description:
         Based on your quiz answers, the role suited to your preferences is
-        a liquidity provider for Threshold. To learn more abouot this role, head
+        a liquidity provider for Threshold. To learn more about this role, head
         to the page below!
       image: /images/liquidity.png
       button:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10868,6 +10868,13 @@ gatsby-plugin-page-creator@^4.9.1:
     globby "^11.0.4"
     lodash "^4.17.21"
 
+gatsby-plugin-posthog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/gatsby-plugin-posthog/-/gatsby-plugin-posthog-1.0.1.tgz#e455720a66d235ed8d7f508e9e575f95e20f189b"
+  integrity sha512-RIyDTj/XcMvmV6Vs6HJa8zQFGcQr52LcS4iD76g5WfFB705hFOAPchIISFoFMQd3qN1n3m4jUinhA/uuhN43Qg==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+
 gatsby-plugin-react-helmet@^5.11.0:
   version "5.11.0"
   resolved "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-5.11.0.tgz#cf20639260fd1fd6180a3cfe1c64da2636ea9655"


### PR DESCRIPTION
This PR adds posthog analystic tool to the T website. We want to enable the
posthog on the production build only so here we pass the
`POSTHOG_SUPPORT: true` env variable in CI during the production build.

**How to test the posthog locally?**
1. Update the posthog plugin config in `gatsby-config.ts` file:
   ```ts
   if (process.env["POSTHOG_SUPPORT"] === "true") {
    plugins.push({
     resolve: "gatsby-plugin-posthog",
     options: {
      apiKey: process.env["POSTHOG_API_KEY"],
      apiHost: process.env["POSTHOG_HOSTNAME_HTTP"],
      isEnabledDevMode: true,
      initOptions: {
       persistence: "memory",
       debug: true,
      },
     },
    })
   }
   ```
2. `POSTHOG_API_KEY=<api_key> POSTHOG_HOSTNAME_HTTP=https://app.posthog.com/
POSTHOG_SUPPORT=true yarn start`
