### PR TITLE
Assorted housekeeping

### DIFF
--- a/src/content/pages/about/index.md
+++ b/src/content/pages/about/index.md
@@ -15,8 +15,8 @@ teamsSection:
   right:
     description:
       NuCypher brings privacy to the public blockchain. NuCypher's proxy
-      re-encryption (PRE) network provides cryptographic access controls for
-      distributed apps and protocols.
+      re-encryption (PRE) and condition-based decryption (CBD) network provides
+      cryptographic access controls for distributed apps and protocols.
     image: /images/nu-logo.png
     buttons:
       - label: Visit NuCypher’s Website
@@ -62,7 +62,7 @@ faq:
             image: /images/document.svg
           rightIcon:
             image: /images/external-arrow.svg
-          url: https://docs.nucypher.com/en/latest/pre_application/node_providers.html
+          url: https://docs.threshold.network/staking-and-running-a-node/running-a-node/staking-providers
     - question: What determines the exchange rate for T tokens?
       answer:
         As decided by the NU and KEEP communities in the final merge proposal,

--- a/src/content/pages/earn/btc.md
+++ b/src/content/pages/earn/btc.md
@@ -3,7 +3,7 @@ template: earn-page/btc
 path: /earn/btc
 title: Earn BTC
 seoTitle: BTC Role
-seoDescription: BTC is Threshold’s decentralized bridge to bring BTC to the
+seoDescription: tBTC is Threshold’s decentralized bridge to bring BTC to the
   Ethereum network; the only permissionless solution on the market today. Bridge
   your Bitcoin to Ethereum in a secure and trustless way to participate in DeFi.
 btcInfo:
@@ -15,14 +15,14 @@ btcInfo:
     in DeFi.
   image: /images/tbtc.png
   buttons:
-    - label: Launch tBTC Dapp
-      url: https://tbtc.network/
+    - label: Launch tBTC v2 Migration Dapp
+      url: https://dashboard.keep.network/tbtc-migration/portal
       variant: EXTERNAL_SOLID
 interestedPools:
   - image1: /images/tbtc-v2.svg
-    image2: /images/mbtc.svg
-    title: TBTCv2 + mBTC
-    subTitle: MSTABLE
-    buttonText: View Pool on mStable
-    buttonUrl: https://mstable.app/#/mbtc/pools/0xc3280306b6218031e61752d060b091278d45c329
+    image2: /images/tbtc-v2.svg
+    title: TBTCv1 -> TBTCv2
+    subTitle: Upgrade
+    buttonText: View Portal
+    buttonUrl: https://dashboard.keep.network/tbtc-migration/portal
 ---

--- a/src/content/pages/earn/liquidity-provider.md
+++ b/src/content/pages/earn/liquidity-provider.md
@@ -23,11 +23,11 @@ interestedPools:
     title: T + ETH
     subTitle: Curve
     buttonText: View Pool on Curve
-    buttonUrl: https://curve.fi/teth
-  - image1: /images/tbtc-v2.svg
-    image2: /images/mbtc.svg
-    title: TBTCv2 + mBTC
-    subTitle: MSTABLE
-    buttonText: View Pool on mStable
-    buttonUrl: https://mstable.app/#/mbtc/pools/0xc3280306b6218031e61752d060b091278d45c329
+    buttonUrl: https://curve.fi/#/ethereum/pools/teth/deposit
+  - image1: /images/threshold.svg
+    image2: /images/ethereum.svg
+    title: T + ETH
+    subTitle: Balancer
+    buttonText: View Pool on Balancer
+    buttonUrl: https://app.balancer.fi/#/ethereum/pool/0x8167a1117691f39e05e9131cfa88f0e3a620e96700020000000000000000038c/invest
 ---

--- a/src/content/pages/earn/staker.md
+++ b/src/content/pages/earn/staker.md
@@ -101,12 +101,12 @@ gettingStarted:
       staking on Threshold.
     links:
       - label: How to Run a Node
-        url: https://docs.nucypher.com/en/latest/pre_application/running_a_node.html
+        url: https://docs.threshold.network/staking-and-running-a-node/running-a-node
         rightIcon: /images/external-arrow.svg
         leftIcon: /images/document.svg
       - leftIcon: /images/hardware-chip-sharp.svg
         label: Staking Providers
-        url: https://docs.nucypher.com/en/latest/pre_application/node_providers.htmlF
+        url: https://docs.threshold.network/staking-and-running-a-node/running-a-node/staking-providers
         rightIcon: /images/external-arrow.svg
       - leftIcon: /images/logo-discord.png
         label: Ask Questions in Discord
@@ -123,19 +123,11 @@ gettingStarted:
       stake on with their T stakes.
     links:
       - leftIcon: /images/t-logo.png
-        label: Threshold
-        url: https://dashboard.threshold.network/
-        rightIcon: /images/external-arrow.svg
-      - leftIcon: /images/nu-token-symbol-1-.svg
-        label: PRE
-        url: https://stake.nucypher.network/
-        rightIcon: /images/external-arrow.svg
-      - leftIcon: /images/keep-token-symbol.svg
-        label: Keep
-        url: https://dashboard.keep.network/
+        label: Threshold Access Control
+        url: https://docs.threshold.network/fundamentals/threshold-access-control
         rightIcon: /images/external-arrow.svg
       - leftIcon: /images/tbtc-v2.svg
-        label: tBTC v2 (coming soon)
-        url: https://github.com/keep-network/tbtc-v2
-        rightIcon: /images/logo-github.png
+        label: tBTC v2
+        url: https://docs.threshold.network/fundamentals/tbtc-v2
+        rightIcon: /images/external-arrow.svg
 ---

--- a/src/content/pages/earn/token-holder.md
+++ b/src/content/pages/earn/token-holder.md
@@ -5,16 +5,16 @@ title: Token Holder
 seoTitle: Threshold Token Holder
 seoDescription: As a Token Holder, you can make the most of your tokens on the
   Threshold Network by participating in DAO governance and voting on what’s next
-  for Threshold. Legacy NU or KEEP tokens should first be migrated to T.
+  for Threshold. Legacy NU or KEEP tokens should first be upgraded to T.
 tokenHolderInfo:
   title: Token Holder
   description: As a Token Holder, you can make the most of your tokens on the
     Threshold Network by participating in DAO governance and voting on what’s
-    next for Threshold. Legacy NU or KEEP tokens should first be migrated to T.
+    next for Threshold. Legacy NU or KEEP tokens should first be upgraded to T.
   image: /images/token-holder.png
   buttons:
-    - label: Migrate to T
-      url: https://dashboard.threshold.network/
+    - label: Upgrade to T
+      url: https://dashboard.threshold.network/upgrade
       variant: EXTERNAL_SOLID
   rowReverse: false
 secondaryInfo:
@@ -32,11 +32,11 @@ secondaryInfo:
     label: Legacy Token Holders
     title: Migrate your KEEP to T
     description:
-      Do you have KEEP or NU tokens? Migrate them to T to make the most
+      Do you have KEEP or NU tokens? Upgrade them to T to make the most
       of the Threshold network.
     buttons:
-      - label: Migrate your tokens
-        url: https://dashboard.threshold.network/
+      - label: Upgrade your tokens
+        url: https://dashboard.threshold.network/upgrade
         variant: EXTERNAL_OUTLINE
 interestedPools:
   - image1: /images/threshold.svg
@@ -44,11 +44,11 @@ interestedPools:
     title: T + ETH
     subTitle: Curve
     buttonText: View Pool on Curve
-    buttonUrl: https://curve.fi/teth
-  - image1: /images/tbtc-v2.svg
-    image2: /images/mbtc.svg
-    title: TBTCv2 + mBTC
-    subTitle: MSTABLE
-    buttonText: View Pool on mStable
-    buttonUrl: https://mstable.app/#/mbtc/pools/0xc3280306b6218031e61752d060b091278d45c329
+    buttonUrl: https://curve.fi/#/ethereum/pools/teth/deposit
+  - image1: /images/threshold.svg
+    image2: /images/ethereum.svg
+    title: T + ETH
+    subTitle: Balancer
+    buttonText: View Pool on Balancer
+    buttonUrl: https://app.balancer.fi/#/ethereum/pool/0x8167a1117691f39e05e9131cfa88f0e3a620e96700020000000000000000038c/invest
 ---

--- a/src/content/pages/governance/index.md
+++ b/src/content/pages/governance/index.md
@@ -6,9 +6,9 @@ seoTitle: Threshold Governance
 governanceInfo:
   title: Governance
   description:
-    "Threshold is governed by a DAO and is a three-pronged system: the
-    Token Holder DAO, Staker DAO and Elected Council. Each of these holds the
-    other two accountable, and they each hold separate responsibilities that are
+    "Threshold is governed by a DAO and is a two-pronged system: the
+    Token Holder DAO and Elected Council. Each of these holds the
+    other accountable, and they each hold separate responsibilities that are
     embedded in the governance structure."
   image: /images/governance.png
   buttons:

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -65,12 +65,12 @@ tokenHolderRole:
   bgColor: "#3c3c3c"
 migrationInfo:
   title: Do you own KEEP or NU?
-  description: Keep and NuCypher merged to form the Threshold Network. Migrate
+  description: Keep and NuCypher merged to form the Threshold Network. Upgrade
     your tokens to T!
   image: /images/legacy-tokens.png
   buttons:
-    - label: Migrate tokens
-      url: https://dashboard.threshold.network/
+    - label: Upgrade tokens
+      url: https://dashboard.threshold.network/upgrade
       variant: EXTERNAL_OUTLINE
   bgColor: "#141414"
   rowReverse: false

--- a/src/templates/governance-page/DaoGovernanceDetails/DaoDelegation.tsx
+++ b/src/templates/governance-page/DaoGovernanceDetails/DaoDelegation.tsx
@@ -53,18 +53,20 @@ const DaoDelegation: FC<{ selectedDao: DAO }> = ({ selectedDao }) => {
   return (
     <PageSection bg="gray.900" withSmallPadding>
       <H4 color="gray.300">
-        {selectedDao === "STAKER" ? "Staker" : "Token Holder"} DAO Delegation
+        {selectedDao === "STAKER" ? "Staker" : "Token Holder"} Delegation
       </H4>
       <ResponsiveStack spacing={12} mt={12}>
         <Card w="full">
           <BodyLg color="gray.100">
             {selectedDao === "STAKER"
-              ? "Members of the Staker DAO are exclusively stakers. Get started below voting on staker proposals."
+              ? "T stakers can delegate their vote using the NuCypher dashboard."
               : "T token holders can delegate their vote using the Boardroom dashboard."}
           </BodyLg>
           <ExternalButtonLink
             href={
-              "https://stake.nucypher.network/manage/delegate" as ExternalLinkHref
+              selectedDao === "STAKER"
+                ? ("https://stake.nucypher.network/manage/delegate" as ExternalLinkHref)
+                : ("https://boardroom.io/threshold/proposals" as ExternalLinkHref)
             }
             mt={8}
           >
@@ -73,7 +75,9 @@ const DaoDelegation: FC<{ selectedDao: DAO }> = ({ selectedDao }) => {
         </Card>
         <Stack w="full" spacing={4} justifyContent="center">
           <LabelMd textTransform="uppercase" color="gray.500">
-            Liquid T Delegated
+            {selectedDao === "STAKER"
+              ? "Staked T Delegated"
+              : "Liquid T Delegated"}
           </LabelMd>
           <H3 color="gray.100">{`${formatTokenAmount(totalDelegated)} T`}</H3>
           <HStack w="full">


### PR DESCRIPTION
This PR makes assorted updates and corrections to the website.

* Pins "source-map": "^0.8.0-beta.0" in package.json as I could not get the site to compile with node v18 otherwise (maybe someone better with node can recommend a better approach)
* Removes any reference to existing tBTC liquidity pools due to the imminent shutdown of renBTC and pending deployment of new pools without such exposure
* Updates various links to point to threshold docs instead of legacy nucypher docs
* Adds Balancer T + ETH pools
* Fixes description of Threshold governace
* Fixes some vote delegation links + staker vs token holder logic
* 