### PR TITLE
Modify the autocapture events for specific buttons

### DIFF
--- a/src/components/Posthog/TrackComponent.tsx
+++ b/src/components/Posthog/TrackComponent.tsx
@@ -1,11 +1,11 @@
 import React, { ReactNode, FC, ReactElement } from "react"
 
-interface TrackedComponentProps {
+interface TrackComponentProps {
   posthogLabel?: string
   children: ReactNode
 }
 
-export const TrackedComponent: FC<TrackedComponentProps> = ({
+export const TrackComponent: FC<TrackComponentProps> = ({
   posthogLabel,
   children,
 }) => {

--- a/src/components/Posthog/TrackedComponents.tsx
+++ b/src/components/Posthog/TrackedComponents.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from "react"
+import { FC } from "react"
+
+interface TrackedComponentProps {
+  posthogLabel?: string
+  children: ReactNode
+}
+
+export const TrackedComponent: FC<TrackedComponentProps> = ({
+  posthogLabel,
+  children,
+}) => {
+  const child = React.Children.only(children)
+  const renderChildren = () => {
+    if (React.isValidElement(child)) {
+      const additionalProps = {} as any
+      if (posthogLabel) {
+        additionalProps["data-ph-capture-attribute-button-name"] = posthogLabel
+        return React.cloneElement(child, additionalProps)
+      }
+    }
+    return child
+  }
+
+  return <>{renderChildren()}</>
+}

--- a/src/components/Posthog/TrackedComponents.tsx
+++ b/src/components/Posthog/TrackedComponents.tsx
@@ -1,5 +1,4 @@
-import React, { ReactNode } from "react"
-import { FC } from "react"
+import React, { ReactNode, FC } from "react"
 
 interface TrackedComponentProps {
   posthogLabel?: string

--- a/src/components/Posthog/TrackedComponents.tsx
+++ b/src/components/Posthog/TrackedComponents.tsx
@@ -10,14 +10,10 @@ export const TrackedComponent: FC<TrackedComponentProps> = ({
   children,
 }) => {
   const child = React.Children.only(children)
-  const renderChildren = () => {
-    const additionalProps = {} as any
-    if (posthogLabel) {
-      additionalProps["data-ph-capture-attribute-button-name"] = posthogLabel
-      return React.cloneElement(child as ReactElement, additionalProps)
-    }
-    return child
-  }
 
-  return <>{renderChildren()}</>
+  return posthogLabel
+    ? React.cloneElement(child as ReactElement, {
+        "data-ph-capture-attribute-button-name": posthogLabel,
+      })
+    : (child as ReactElement)
 }

--- a/src/components/Posthog/TrackedComponents.tsx
+++ b/src/components/Posthog/TrackedComponents.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, FC } from "react"
+import React, { ReactNode, FC, ReactElement } from "react"
 
 interface TrackedComponentProps {
   posthogLabel?: string
@@ -11,12 +11,10 @@ export const TrackedComponent: FC<TrackedComponentProps> = ({
 }) => {
   const child = React.Children.only(children)
   const renderChildren = () => {
-    if (React.isValidElement(child)) {
-      const additionalProps = {} as any
-      if (posthogLabel) {
-        additionalProps["data-ph-capture-attribute-button-name"] = posthogLabel
-        return React.cloneElement(child, additionalProps)
-      }
+    const additionalProps = {} as any
+    if (posthogLabel) {
+      additionalProps["data-ph-capture-attribute-button-name"] = posthogLabel
+      return React.cloneElement(child as ReactElement, additionalProps)
     }
     return child
   }

--- a/src/content/pages/earn/btc.md
+++ b/src/content/pages/earn/btc.md
@@ -18,6 +18,7 @@ btcInfo:
     - label: Mint tBTC
       url: https://dashboard.threshold.network/tBTC
       variant: EXTERNAL_SOLID
+      posthogLabel: Mint tBTC [btcInfo] (/earn/btc)
 interestedPools:
   - image1: /images/tbtc-v2.svg
     image2: /images/tbtc-v2.svg

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -8,8 +8,10 @@ hero:
   ctaButtons:
     - label: Mint tBTC
       url: https://dashboard.threshold.network/tBTC
+      posthogLabel: Mint tBTC [hero] (Main page)
     - label: Stay Updated
       url: https://twitter.com/TheTNetwork
+      posthogLabel: Stay Updated [hero] (Main page)
   image: /images/tbtc-dashboard.png
 stakerRole:
   title: Threshold Staking
@@ -45,9 +47,11 @@ btcRole:
     - label: Stay Updated
       url: https://twitter.com/TheTNetwork
       variant: EXTERNAL_SOLID
+      posthogLabel: Stay Updated [btcRole] (Main page)
     - label: Learn More
       url: /earn/btc
       variant: INTERNAL_OUTLINE
+      posthogLabel: Learn More [btcRole] (Main page)
   rowReverse: false
   bgColor: "#333333"
 tokenHolderRole:

--- a/src/templates/earn-page/btc/index.tsx
+++ b/src/templates/earn-page/btc/index.tsx
@@ -45,6 +45,7 @@ export const query = graphql`
             label
             url
             variant
+            posthogLabel
           }
         }
         interestedPools {

--- a/src/templates/home-page/Hero/index.tsx
+++ b/src/templates/home-page/Hero/index.tsx
@@ -56,6 +56,7 @@ const Hero: FC<{
                       {...heroButtonProps}
                       variant={index === 0 ? "special" : "outline"}
                       href={_.url as ExternalLinkHref}
+                      data-ph-capture-attribute-button-name={`${_.label} (${window.location.href})`}
                     >
                       <ButtonLg>{_.label}</ButtonLg>
                     </ExternalButtonLink>

--- a/src/templates/home-page/Hero/index.tsx
+++ b/src/templates/home-page/Hero/index.tsx
@@ -49,14 +49,23 @@ const Hero: FC<{
               spacing={12}
             >
               {ctaButtons.map(
-                (_: { label: string; url: string }, index: number) => {
+                (
+                  _: { label: string; url: string; posthogLabel: string },
+                  index: number
+                ) => {
+                  const additionalProps = {} as any
+                  if (_.posthogLabel) {
+                    additionalProps["data-ph-capture-attribute-button-name"] =
+                      _.posthogLabel
+                  }
+
                   return (
                     <ExternalButtonLink
                       key={_.label}
                       {...heroButtonProps}
                       variant={index === 0 ? "special" : "outline"}
                       href={_.url as ExternalLinkHref}
-                      data-ph-capture-attribute-button-name={`${_.label} (${window.location.href})`}
+                      {...additionalProps}
                     >
                       <ButtonLg>{_.label}</ButtonLg>
                     </ExternalButtonLink>

--- a/src/templates/home-page/Hero/index.tsx
+++ b/src/templates/home-page/Hero/index.tsx
@@ -5,6 +5,7 @@ import heroGradientBg from "../../../static/images/hero-gradient-bg.png"
 import ExternalButtonLink from "../../../components/Buttons/ExternalButtonLink"
 import { ExternalLinkHref } from "../../../components/Navbar/types"
 import { Image, ImageProps } from "../../../components/Image"
+import { TrackedComponent } from "../../../components/Posthog/TrackedComponents"
 
 const heroButtonProps = {
   h: "auto",
@@ -53,22 +54,17 @@ const Hero: FC<{
                   _: { label: string; url: string; posthogLabel: string },
                   index: number
                 ) => {
-                  const additionalProps = {} as any
-                  if (_.posthogLabel) {
-                    additionalProps["data-ph-capture-attribute-button-name"] =
-                      _.posthogLabel
-                  }
-
                   return (
-                    <ExternalButtonLink
-                      key={_.label}
-                      {...heroButtonProps}
-                      variant={index === 0 ? "special" : "outline"}
-                      href={_.url as ExternalLinkHref}
-                      {...additionalProps}
-                    >
-                      <ButtonLg>{_.label}</ButtonLg>
-                    </ExternalButtonLink>
+                    <TrackedComponent posthogLabel={_.posthogLabel}>
+                      <ExternalButtonLink
+                        key={_.label}
+                        {...heroButtonProps}
+                        variant={index === 0 ? "special" : "outline"}
+                        href={_.url as ExternalLinkHref}
+                      >
+                        <ButtonLg>{_.label}</ButtonLg>
+                      </ExternalButtonLink>
+                    </TrackedComponent>
                   )
                 }
               )}

--- a/src/templates/home-page/Hero/index.tsx
+++ b/src/templates/home-page/Hero/index.tsx
@@ -5,7 +5,7 @@ import heroGradientBg from "../../../static/images/hero-gradient-bg.png"
 import ExternalButtonLink from "../../../components/Buttons/ExternalButtonLink"
 import { ExternalLinkHref } from "../../../components/Navbar/types"
 import { Image, ImageProps } from "../../../components/Image"
-import { TrackedComponent } from "../../../components/Posthog/TrackedComponents"
+import { TrackComponent } from "../../../components/Posthog/TrackComponent"
 
 const heroButtonProps = {
   h: "auto",
@@ -55,10 +55,7 @@ const Hero: FC<{
                   index: number
                 ) => {
                   return (
-                    <TrackedComponent
-                      posthogLabel={_.posthogLabel}
-                      key={_.label}
-                    >
+                    <TrackComponent posthogLabel={_.posthogLabel} key={_.label}>
                       <ExternalButtonLink
                         {...heroButtonProps}
                         variant={index === 0 ? "special" : "outline"}
@@ -66,7 +63,7 @@ const Hero: FC<{
                       >
                         <ButtonLg>{_.label}</ButtonLg>
                       </ExternalButtonLink>
-                    </TrackedComponent>
+                    </TrackComponent>
                   )
                 }
               )}

--- a/src/templates/home-page/Hero/index.tsx
+++ b/src/templates/home-page/Hero/index.tsx
@@ -55,9 +55,11 @@ const Hero: FC<{
                   index: number
                 ) => {
                   return (
-                    <TrackedComponent posthogLabel={_.posthogLabel}>
+                    <TrackedComponent
+                      posthogLabel={_.posthogLabel}
+                      key={_.label}
+                    >
                       <ExternalButtonLink
-                        key={_.label}
                         {...heroButtonProps}
                         variant={index === 0 ? "special" : "outline"}
                         href={_.url as ExternalLinkHref}

--- a/src/templates/home-page/SectionTemplate.tsx
+++ b/src/templates/home-page/SectionTemplate.tsx
@@ -73,6 +73,7 @@ const SectionTemplate: FC<RoleTemplateProps> = ({
                 key={_.label}
                 cmsVariant={_.variant as ButtonType}
                 url={_.url}
+                data-ph-capture-attribute-button-name={`${_.label} (${window.location.href})`}
               >
                 {_.label}
               </CmsButtonLink>

--- a/src/templates/home-page/SectionTemplate.tsx
+++ b/src/templates/home-page/SectionTemplate.tsx
@@ -12,6 +12,7 @@ import {
   SectionTextContainer,
 } from "../../components/PageSection"
 import { ImageProps } from "../../components"
+import { TrackedComponent } from "../../components/Posthog/TrackedComponents"
 
 export interface FooterButton {
   label: string
@@ -70,20 +71,16 @@ const SectionTemplate: FC<RoleTemplateProps> = ({
 
           <Stack mt={10} direction={{ base: "column", md: "row" }} spacing={8}>
             {buttons.map((_: FooterButton, i) => {
-              const additionalProps = {} as any
-              if (_.posthogLabel) {
-                additionalProps["data-ph-capture-attribute-button-name"] =
-                  _.posthogLabel
-              }
               return (
-                <CmsButtonLink
-                  key={_.label}
-                  cmsVariant={_.variant as ButtonType}
-                  url={_.url}
-                  {...additionalProps}
-                >
-                  {_.label}
-                </CmsButtonLink>
+                <TrackedComponent posthogLabel={_.posthogLabel}>
+                  <CmsButtonLink
+                    key={_.label}
+                    cmsVariant={_.variant as ButtonType}
+                    url={_.url}
+                  >
+                    {_.label}
+                  </CmsButtonLink>
+                </TrackedComponent>
               )
             })}
           </Stack>

--- a/src/templates/home-page/SectionTemplate.tsx
+++ b/src/templates/home-page/SectionTemplate.tsx
@@ -12,7 +12,7 @@ import {
   SectionTextContainer,
 } from "../../components/PageSection"
 import { ImageProps } from "../../components"
-import { TrackedComponent } from "../../components/Posthog/TrackedComponents"
+import { TrackComponent } from "../../components/Posthog/TrackComponent"
 
 export interface FooterButton {
   label: string
@@ -72,14 +72,14 @@ const SectionTemplate: FC<RoleTemplateProps> = ({
           <Stack mt={10} direction={{ base: "column", md: "row" }} spacing={8}>
             {buttons.map((_: FooterButton, i) => {
               return (
-                <TrackedComponent posthogLabel={_.posthogLabel} key={_.label}>
+                <TrackComponent posthogLabel={_.posthogLabel} key={_.label}>
                   <CmsButtonLink
                     cmsVariant={_.variant as ButtonType}
                     url={_.url}
                   >
                     {_.label}
                   </CmsButtonLink>
-                </TrackedComponent>
+                </TrackComponent>
               )
             })}
           </Stack>

--- a/src/templates/home-page/SectionTemplate.tsx
+++ b/src/templates/home-page/SectionTemplate.tsx
@@ -72,9 +72,8 @@ const SectionTemplate: FC<RoleTemplateProps> = ({
           <Stack mt={10} direction={{ base: "column", md: "row" }} spacing={8}>
             {buttons.map((_: FooterButton, i) => {
               return (
-                <TrackedComponent posthogLabel={_.posthogLabel}>
+                <TrackedComponent posthogLabel={_.posthogLabel} key={_.label}>
                   <CmsButtonLink
-                    key={_.label}
                     cmsVariant={_.variant as ButtonType}
                     url={_.url}
                   >

--- a/src/templates/home-page/SectionTemplate.tsx
+++ b/src/templates/home-page/SectionTemplate.tsx
@@ -17,6 +17,7 @@ export interface FooterButton {
   label: string
   url: string
   variant: string
+  posthogLabel?: string
 }
 
 export interface RoleTemplateProps extends BoxProps {
@@ -68,16 +69,23 @@ const SectionTemplate: FC<RoleTemplateProps> = ({
           )}
 
           <Stack mt={10} direction={{ base: "column", md: "row" }} spacing={8}>
-            {buttons.map((_: FooterButton, i) => (
-              <CmsButtonLink
-                key={_.label}
-                cmsVariant={_.variant as ButtonType}
-                url={_.url}
-                data-ph-capture-attribute-button-name={`${_.label} (${window.location.href})`}
-              >
-                {_.label}
-              </CmsButtonLink>
-            ))}
+            {buttons.map((_: FooterButton, i) => {
+              const additionalProps = {} as any
+              if (_.posthogLabel) {
+                additionalProps["data-ph-capture-attribute-button-name"] =
+                  _.posthogLabel
+              }
+              return (
+                <CmsButtonLink
+                  key={_.label}
+                  cmsVariant={_.variant as ButtonType}
+                  url={_.url}
+                  {...additionalProps}
+                >
+                  {_.label}
+                </CmsButtonLink>
+              )
+            })}
           </Stack>
         </SectionTextContainer>
         {image && <SectionImage {...image} />}

--- a/src/templates/home-page/index.tsx
+++ b/src/templates/home-page/index.tsx
@@ -49,6 +49,7 @@ export const query = graphql`
           ctaButtons {
             label
             url
+            posthogLabel
           }
           image {
             id

--- a/src/templates/home-page/index.tsx
+++ b/src/templates/home-page/index.tsx
@@ -120,6 +120,7 @@ export const query = graphql`
             label
             url
             variant
+            posthogLabel
           }
         }
         tokenHolderRole {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -75,6 +75,11 @@ collections:
                     [
                       { label: Label, name: label, widget: string },
                       { label: URL, name: url, widget: string },
+                      {
+                        label: Posthog Label,
+                        name: posthogLabel,
+                        widget: string,
+                      },
                     ],
                 }
           - label: "Staker Role"
@@ -276,6 +281,11 @@ collections:
                               value: "INTERNAL_OUTLINE",
                             },
                           ],
+                      },
+                      {
+                        label: Posthog Label,
+                        name: posthogLabel,
+                        widget: string,
                       },
                     ],
                 }
@@ -831,6 +841,11 @@ collections:
                                 value: "INTERNAL_OUTLINE",
                               },
                             ],
+                        },
+                        {
+                          label: Posthog Label,
+                          name: posthogLabel,
+                          widget: string,
                         },
                       ],
                   },


### PR DESCRIPTION
Ref: https://github.com/threshold-network/token-dashboard/issues/479

Modify the autocapture events for posthog for specific buttons. We want to track how many users clicked the "Mint tBTC" button from main page, "Learn more" from tBTC section on main page and "Mint tbtc" button from "/earn/btc" page. For that we are using specific attribute that allow us to add additional properties to the autocapture event:

`data-ph-capture-attribute-{property-name}={value}`

We use `button-name` as a property name and `${buttonName} ${currentUrl}`. I've added the `currentUrl` to the value so we can differentiate the "Mint tbtc" button from main page from the one from "eart/btc" page.

Thanks to that we can use filter in the PostHog dashboard to filter out those specific button. We could use that to count how many users clicked on that specific button.