### PR TITLE
Add `Docs` link

### DIFF
--- a/src/content/components/footer.md
+++ b/src/content/components/footer.md
@@ -45,6 +45,9 @@ columns:
         isExternal: true
   - title: About
     links:
+      - label: Docs
+        url: https://docs.threshold.network/
+        isExternal: true
       - label: Contributors
         url: /about#contributors
         isExternal: false

--- a/src/content/components/nav-bar.md
+++ b/src/content/components/nav-bar.md
@@ -23,6 +23,9 @@ nav_items:
         isExternal: true
   - label: About
     subitems:
+      - label: Docs
+        url: https://docs.threshold.network/
+        isExternal: true
       - label: Contributors
         url: /about#contributors
       - label: FAQ

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -176,6 +176,13 @@ joinTheCommunity:
           icon:
             image: /images/logo-github.png
             alt: github
+        - label: Docs
+          url:  https://docs.threshold.network/
+          image: /images/document.svg
+          variant: INTERNAL_OUTLINE
+          icon:
+            image: /images/document.svg
+            alt: docs
 title: Threshold Network
 description: Threshold powers user sovereignty on the public blockchain.
 ---


### PR DESCRIPTION
Ref: https://github.com/threshold-network/token-dashboard/issues/509

- to the nav bar under the `About` section,
- to the footer under the `About` section,
- as a button with document icon next to the Github button under the `For developers` section on the home page.