### PR TITLE
Update codeowners for mainnet CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows/ci.yaml @pdyraga @nkuba @lukasz-zimnoch
+.github/workflows/ci.yaml @pdyraga @lukasz-zimnoch @cygnusv


### PR DESCRIPTION
According to the recent arrangements from the Threshold Product Sync meeting, here we add @cygnusv as an additional code owner for the mainnet CI config file.