### PR TITLE
More items in Gov dropdown

### DIFF
--- a/src/content/components/nav-bar.md
+++ b/src/content/components/nav-bar.md
@@ -22,6 +22,15 @@ nav_items:
         isExternal: true
   - label: Governance
     url: /governance
+    subitems:
+      - label: Threshold DAO
+        url: /governance
+      - label: Forum
+        url: https://forum.threshold.network/
+        isExternal: true
+      - label: Delegate Vote
+        url: https://delegates.threshold.network/
+        isExternal: true
   - label: Ecosystem
     url: /ecosystem
   - label: About


### PR DESCRIPTION
**Ref:** ENG-247 `Make sure this is linked in our website so it is accessible from it.`

Before: link to `/governance` only
<img width="1115" height="926" alt="image" src="https://github.com/user-attachments/assets/bf6788f1-685d-4e28-9f5e-167080ec7aca" />

Now: link to `/governance`, link to `forum.threshold.network`, link to `delegates.threshold.network` (delegates network will be non-searchable in the delegates repo)
<img width="1214" height="553" alt="image" src="https://github.com/user-attachments/assets/e72568c5-5dc5-4d62-9ac4-c797d1d410a1" />
